### PR TITLE
Improve memory allocation safety for guest data

### DIFF
--- a/rmi4update/rmi4update.cpp
+++ b/rmi4update/rmi4update.cpp
@@ -672,9 +672,13 @@ int RMI4Update::ReadFlashConfig()
 	fprintf(stdout, "F34 guest blocks:     %d\n", m_guestBlockCount);
 	fprintf(stdout, "\n");
 
-	m_guestData = (unsigned char *) malloc(m_guestBlockCount * m_blockSize);
-	memset(m_guestData, 0, m_guestBlockCount * m_blockSize);
-	memset(m_guestData + m_guestBlockCount * m_blockSize -4, 0, 4);
+	if(m_partitionGuest != NULL && (m_guestBlockCount * m_blockSize) >= 4) {
+		m_guestData = (unsigned char *) malloc(m_guestBlockCount * m_blockSize);
+		if (m_guestData != NULL) {
+			memset(m_guestData, 0, m_guestBlockCount * m_blockSize);
+			memset(m_guestData + m_guestBlockCount * m_blockSize -4, 0, 4);
+		}
+	}
 	return UPDATE_SUCCESS;
 }
 


### PR DESCRIPTION
Add null check for m_partitionGuest and check minimum size before allocating guest data.